### PR TITLE
#159648566 Add logic for the functionality of the modify-entry page using the fetch-API

### DIFF
--- a/client/js/add-entry.js
+++ b/client/js/add-entry.js
@@ -1,8 +1,3 @@
-
-function displayErrorInFields(errors, field){
-    document.getElementById(field+'Error').innerHTML = '<h1 class="errorField">'+ errors[field] +'</h1>';
-}
-
 function processAddEntry(){
     const url = 'https://deploy-challenge3-to-heroku.herokuapp.com/api/v1/entries';
     const token = localStorage.getItem('token');

--- a/client/js/all-entries.js
+++ b/client/js/all-entries.js
@@ -16,6 +16,11 @@ function viewEntry(id){
     window.location.href = 'single-entry.html'; 
 }
 
+function modifyEntry(id){
+    window.localStorage.setItem('entryId', id);
+    window.location.href = 'modify-entry.html'; 
+}
+
 function entryThumbnail(entry){
     let position = '';
     if(entry.entry_id % 2 === 0){
@@ -32,7 +37,7 @@ function entryThumbnail(entry){
         '<p class="entry-text"><a href="single-entry.html">'+ entry.content +'</a></p>' +
          '<div class="actions">' +
         '<a href="single-entry.html"><button onclick="viewEntry('+ entry.entry_id+')" type="submit" class="action-link read-more">Read More</button></a>' +
-        '<a href="modify-entry.html"><button type="submit" class="action-link modify-entry">Modify</button></a>' +
+        '<a href="modify-entry.html"><button onclick="modifyEntry('+ entry.entry_id+')" type="submit" class="action-link modify-entry">Modify</button></a>' +
         '<a><button type="submit" id="entry1" class="action-link delete-entry" onclick="deleteEntry()">Delete</button></a>' +
         '</div></div></div>';
 }

--- a/client/js/modify-entry.js
+++ b/client/js/modify-entry.js
@@ -1,0 +1,73 @@
+function modifyEntry(){
+    const entryId = localStorage.getItem('entryId');
+    const url = 'https://deploy-challenge3-to-heroku.herokuapp.com/api/v1/entries/' + entryId;
+    const token = localStorage.getItem('token');
+    const dataForFetch = { 
+        method: 'GET', 
+        headers: { 
+            "Content-Type": "application/json",
+            "authentication": token
+         }
+        }
+
+    fetch(url, dataForFetch)
+    .then((res) => res.json()) 
+    .then((data) => {
+        console.log(data);
+        if(data.authenticated === false || data.errors){
+            window.location.href = 'sign-in.html';
+            document.getElementById("errorMessage").innerHTML =
+            '<h1 class="errorField"> You have to login! </h1>'; 
+        } else {
+            window.localStorage.setItem('entryId', entryId);
+            document.getElementById('title').value = data.title;
+            document.getElementById('content').value = data.content;
+        }
+
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+
+      return false;
+}
+
+modifyEntry();
+
+
+function processModifyEntry(){
+    const entryId = localStorage.getItem('entryId');
+    const url = 'https://deploy-challenge3-to-heroku.herokuapp.com/api/v1/entries/' + entryId;
+    const token = localStorage.getItem('token');
+
+    let title = document.forms["modifyEntry"]["title"].value;
+    let content = document.forms["modifyEntry"]["content"].value;
+
+    const dataForFetch = { 
+        method: 'PUT', 
+        body: JSON.stringify({ title, content }),
+        headers: { 
+            "Content-Type": "application/json",
+            "authentication": token
+         }
+        }
+
+    fetch(url, dataForFetch)
+    .then((res) => res.json()) 
+    .then((data) => {
+        console.log(data);
+        if(data.authenticated === false || data.errors){
+            window.location.href = 'sign-in.html';
+            document.getElementById("errorMessage").innerHTML =
+            '<h1 class="errorField"> You have to login! </h1>'; 
+        } else {
+            window.location.href = 'all-entries.html';
+        }
+
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+
+      return false;
+}

--- a/client/modify-entry.html
+++ b/client/modify-entry.html
@@ -9,6 +9,7 @@
   <meta name="description" content="Modify entry"/>
   <title>MyDiary - Modify Entry </title>
   <link href="css/styles.css" rel="stylesheet" />
+  <script type="text/javascript" src="js/modify-entry.js"></script>
 </head>
 <body>
 
@@ -28,14 +29,14 @@
 
         <h1 class="page-header">Modify Entry</h1>
 
-        <form name="modifyEntry" class="signup-form" action="single-entry.html" onsubmit="return validateModifyEntryForm()">
+        <form name="modifyEntry" class="signup-form" action="single-entry.html" onsubmit="return processModifyEntry()">
             <div class="form-group">
               <label  class="input-label" for="Title">Title</label>
-              <input type="text" class="form-field" id="Title" value="My First Day in School">
+              <input name="title" type="text" class="form-field" id="title" value="My First Day in School">
             </div>
             <div class="form-group">
               <label  class="input-label" for="Entry_content">Entry Content</label>
-              <textarea type="password" height="50px" class="form-field form-field-textarea" id="Entry_content">Lorem ipsum dolor sit amet,adipiscing elit. Etiam pulv inar, mauris sit amet interdum feugiat
+              <textarea name="content" type="password" height="50px" class="form-field form-field-textarea" id="content">Lorem ipsum dolor sit amet,adipiscing elit. Etiam pulv inar, mauris sit amet interdum feugiat
               </textarea>
               <div id="entryContentError"></div>
             </div>
@@ -50,7 +51,7 @@
                   Designed & Developed by Victor Ukafor
         </div>
 </footer>
-<script type="text/javascript" src="js/script.js"></script>
+
 </body>
 </html>
    

--- a/server/controllers/entries.js
+++ b/server/controllers/entries.js
@@ -170,7 +170,7 @@ export default class EntryController {
     let content = '';
 
     if(req.body.title){ title = req.body.title.trim(); }
-    if(req.body.content){ title = req.body.content.trim(); }
+    if(req.body.content){ content = req.body.content.trim(); }
 
     const titleUpdated = this.setTitleForUpdate(title, req.entry);
     const contentUpdated = this.setContentForUpdate(content, req.entry);


### PR DESCRIPTION

What does this PR do?

This PR modifies an entry of an authenticated user using data fetched by the fetch-API

Description of Task to be completed?

- adds  onclick event to entries displayed on the all-entries page.
- Write logic for pre-filling the modify-entry form with title and content of an entry to be updated.
- Write logic for the modifying an entry when the submit button is clicked.
- fixed a bug on the logic for modifying an entry.


What are the relevant pivotal tracker stories?

- story type: feature
- story id: #159648566 
- story title:  Add logic for the functionality of the `modify-entry` page using the fetch-API 

screenshot
N/A

Questions

N/A